### PR TITLE
feat: adicioando tela de detalhes do pokemon

### DIFF
--- a/src/app/Services/pokemon/pokemon.component.ts
+++ b/src/app/Services/pokemon/pokemon.component.ts
@@ -10,33 +10,73 @@ import { Pokemon } from '../../Types/pokemon';
 export class PokemonService {
   private baseUrl = 'https://pokeapi.co/api/v2';
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
+  /**
+   * @param limit The number of Pokemons to fetch.
+   * @param offset The starting offset for the list.
+   * @returns An Observable array of Pokemon objects.
+   */
   getPokemons(limit: number = 20, offset: number = 0): Observable<Pokemon[]> {
     return this.http.get<any>(`${this.baseUrl}/pokemon?limit=${limit}&offset=${offset}`).pipe(
       map(response => response.results),
       switchMap(pokemonList => {
-        if (pokemonList && pokemonList.length > 0) {
-          const detailedPokemonRequests: Observable<Pokemon>[] = pokemonList.map((pokemon: any) =>
-            this.http.get<any>(pokemon.url).pipe(
-              map(detail => this.transformPokemonData(detail))
-            )
-          );
-          return forkJoin<Pokemon[]>(detailedPokemonRequests);
-        } else {
-          return of([]); // Retorna um array vazio se não houver pokémons
+        // If the list is empty, return an empty array immediately.
+        if (!pokemonList || pokemonList.length === 0) {
+          return of([]);
         }
+
+        const detailedRequests: Observable<Pokemon>[] = pokemonList.map((pokemon: any) =>
+          this.http.get<any>(pokemon.url).pipe(
+            switchMap(detail =>
+              this.http.get<any>(`${this.baseUrl}/pokemon-species/${detail.id}`).pipe(
+                map(speciesData => {
+                  // Prioritize Portuguese description, fall back to English if not found
+                  const flavorTextEntry =
+                    speciesData.flavor_text_entries.find((entry: any) => entry.language.name === 'pt') ||
+                    speciesData.flavor_text_entries.find((entry: any) => entry.language.name === 'en');
+
+                  return this.transformPokemonData(detail, flavorTextEntry?.flavor_text || 'Description unavailable');
+                })
+              )
+            )
+          )
+        );
+
+        return forkJoin(detailedRequests);
       })
     );
   }
 
+  /**
+   * Retrieves detailed information for a single Pokemon.
+   * @param id The ID or name of the Pokemon.
+   * @returns An Observable of a single Pokemon object.
+   */
   getPokemonDetails(id: string | number): Observable<Pokemon> {
     return this.http.get<any>(`${this.baseUrl}/pokemon/${id}`).pipe(
-      map(detail => this.transformPokemonData(detail))
+      switchMap((data) =>
+        this.http.get<any>(`${this.baseUrl}/pokemon-species/${id}`).pipe(
+          map((speciesData) => {
+            // Prioritize Portuguese description, fall back to English if not found
+            const flavorTextEntry =
+              speciesData.flavor_text_entries.find((entry: any) => entry.language.name === 'pt') ||
+              speciesData.flavor_text_entries.find((entry: any) => entry.language.name === 'en');
+
+            return this.transformPokemonData(data, flavorTextEntry?.flavor_text || 'Description unavailable');
+          })
+        )
+      )
     );
   }
 
-  private transformPokemonData(data: any): Pokemon {
+  /**
+   * Transforms raw Pokemon API data into the custom Pokemon interface.
+   * @param data The raw Pokemon data from the API.
+   * @param description The extracted flavor text description.
+   * @returns A formatted Pokemon object.
+   */
+  private transformPokemonData(data: any, description: string): Pokemon {
     const types = data.types.map((typeInfo: any) => typeInfo.type.name);
 
     return {
@@ -44,11 +84,11 @@ export class PokemonService {
       name: data.name.charAt(0).toUpperCase() + data.name.slice(1),
       type: types.map((type: string) => type.charAt(0).toUpperCase() + type.slice(1)).join('/'),
       types: types,
-      description: 'Ainda não implementado (descrição da API não disponível diretamente aqui).',
+      description: description.replace(/\n|\f/g, ' '), // Cleans newlines and form feeds from description
       imageUrl: data.sprites.other['official-artwork'].front_default || data.sprites.front_default,
       level: Math.floor(Math.random() * 100) + 1,
-      height: data.height / 10,
-      weight: data.weight / 10,
+      height: data.height / 10, // Convert decimetres to meters
+      weight: data.weight / 10, // Convert hectograms to kilograms
     };
   }
 }

--- a/src/app/details/main-details.component.html
+++ b/src/app/details/main-details.component.html
@@ -1,5 +1,77 @@
 <app-main-header></app-main-header>
 
-<p>
-  main-details works!
-</p>
+<ion-content [fullscreen]="true" class="ion-padding">
+  <div *ngIf="isLoading" class="loading-spinner">
+    <ion-spinner name="crescent"></ion-spinner>
+    <p>Carregando detalhes do Pokémon...</p>
+  </div>
+
+  <ion-grid *ngIf="!isLoading && pokemon" class="details-container">
+    <ion-row class="ion-align-items-center ion-justify-content-center">
+      <ion-col size="12" size-md="6" class="pokemon-image-col">
+        <ion-card class="pokemon-image-card">
+          <ion-img [src]="pokemon.imageUrl" [alt]="pokemon.name" class="pokemon-detail-image"></ion-img>
+        </ion-card>
+        <ion-tab-button tab="home" routerLink="/tabs/home" class="btn_home">
+          <ion-label>Voltar</ion-label>
+        </ion-tab-button>
+      </ion-col>
+
+      <ion-col size="12" size-md="6" class="pokemon-details-col">
+        <ion-card class="pokemon-details-card">
+          <ion-card-content>
+            <ion-text>
+              <h1 class="pokemon-name-detail">{{ pokemon.name }}</h1>
+            </ion-text>
+
+            <ion-list lines="none">
+              <ion-item>
+                <ion-label>
+                  <p><strong>ID:</strong> #{{ pokemon.id }}</p>
+                </ion-label>
+              </ion-item>
+              <ion-item>
+                <ion-label>
+                  <p><strong>Tipo:</strong> {{ pokemon.type }}</p>
+                </ion-label>
+              </ion-item>
+              <ion-item>
+                <ion-label>
+                  <p><strong>Tipos:</strong> {{ pokemon.types.join(', ') | uppercase }}</p>
+                </ion-label>
+              </ion-item>
+              <ion-item>
+                <ion-label>
+                  <p><strong>Altura:</strong> {{ pokemon.height }} m</p>
+                </ion-label>
+              </ion-item>
+              <ion-item>
+                <ion-label>
+                  <p><strong>Peso:</strong> {{ pokemon.weight }} kg</p>
+                </ion-label>
+              </ion-item>
+              <ion-item>
+                <ion-label>
+                  <p><strong>Nível:</strong> {{ pokemon.level }}</p>
+                  <ion-progress-bar [value]="pokemon.level / 100"></ion-progress-bar>
+                </ion-label>
+              </ion-item>
+              <ion-item>
+                <ion-label>
+                  <h3>Descrição:</h3>
+                  <p class="pokemon-description-text">{{ pokemon.description }}</p>
+                </ion-label>
+              </ion-item>
+            </ion-list>
+          </ion-card-content>
+        </ion-card>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
+
+  <div *ngIf="!isLoading && !pokemon" class="no-data-message">
+    <ion-text color="medium">
+      <p>Nenhum detalhe de Pokémon encontrado.</p>
+    </ion-text>
+  </div>
+</ion-content>

--- a/src/app/details/main-details.component.scss
+++ b/src/app/details/main-details.component.scss
@@ -1,0 +1,125 @@
+@use '../../theme/variables' as *;
+.loading-spinner {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  color: var(--ion-color-medium);
+}
+
+.details-container {
+  padding: 1rem;
+  max-width: 1200px;
+  margin: auto;
+  margin-top: 4%;
+}
+
+.pokemon-image-col,
+.pokemon-details-col {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px;
+  width: 100%;
+}
+
+.pokemon-image-card {
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  box-shadow: var(--ion-box-shadow);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  
+  align-items: center;
+  background: var(--ion-color-light);
+
+  .pokemon-detail-image {
+    width: 100%;
+    height: auto;
+    object-fit: contain;
+    padding: 10px;
+  }
+  
+}
+.btn_home{
+  background-color: $secundery-color;
+  position: absolute;
+  height: 7vh;
+  width: 80%;
+  bottom: 0;
+  color:$white-text-button;
+  transition: all 0.5s;
+  border-radius: 5px;
+
+}
+.btn_home:hover{
+  background-color: $color-links;
+}
+.pokemon-details-card {
+  width: 100%;
+  height: 90svh;
+  box-shadow: var(--ion-box-shadow);
+  border-radius: 12px;
+  background: var(--ion-color-light);
+  overflow-y: auto;
+
+  ion-card-content {
+    padding: 20px;
+
+    .pokemon-name-detail {
+      font-size: 2.2em;
+      font-weight: bold;
+      text-align: center;
+      text-transform: capitalize;
+      margin-bottom: 20px;
+      color: var(--ion-color-primary);
+    }
+
+    ion-list {
+      background: transparent;
+      padding: 0;
+    }
+
+    ion-item {
+      --background: transparent;
+      padding-top: 8px;
+      padding-bottom: 8px;
+
+      ion-label {
+        white-space: normal;
+
+        p {
+          margin: 0;
+          font-size: 1em;
+          color: var(--ion-color-medium);
+
+          strong {
+            color: var(--ion-color-dark);
+          }
+        }
+
+        h3 {
+          margin-top: 15px;
+          margin-bottom: 5px;
+          color: var(--ion-color-dark);
+          font-size: 1.1em;
+        }
+      }
+    }
+
+    .pokemon-description-text {
+      font-style: italic;
+      color: var(--ion-color-medium-shade);
+    }
+  }
+}
+
+.no-data-message {
+  text-align: center;
+  padding: 20px;
+  color: var(--ion-color-medium);
+}

--- a/src/app/details/main-details.component.ts
+++ b/src/app/details/main-details.component.ts
@@ -1,18 +1,100 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute } from '@angular/router'; // Para obter o ID da URL
+import { CommonModule } from '@angular/common'; // Para usar *ngIf, etc.
+import { Subscription } from 'rxjs'; // Para gerenciar a inscrição do Observable
+
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonGrid,
+  IonRow,
+  IonCol,
+  IonImg,
+  IonText,
+  IonProgressBar,
+  IonSpinner, // Para exibir um spinner durante o carregamento
+  IonCard,
+  IonCardContent,
+  IonLabel,
+  IonItem,
+  IonList, IonTabButton } from '@ionic/angular/standalone';
+
 import { MainHeaderComponent } from "../components/main-header/main-header.component";
-
-
+import { PokemonService } from '../Services/pokemon/pokemon.component'; // Importe o serviço
+import { Pokemon } from '../Types/pokemon'; // Importe a interface do Pokémon
+import { HttpClientModule } from '@angular/common/http';
 @Component({
   selector: 'app-main-details',
   templateUrl: './main-details.component.html',
   styleUrls: ['./main-details.component.scss'],
   standalone: true,
-  imports: [MainHeaderComponent],
+  imports: [IonTabButton, 
+    CommonModule,
+    MainHeaderComponent, 
+    IonContent,
+    IonGrid,
+    IonRow,
+    IonCol,
+    IonImg,
+    IonText,
+    IonProgressBar,
+    IonSpinner,
+    IonCard,
+    IonCardContent,
+    IonLabel,
+    IonItem,
+    IonList,
+    HttpClientModule
+  ],
+  providers: [PokemonService] 
 })
-export class MainDetailsComponent  implements OnInit {
+export class MainDetailsComponent implements OnInit, OnDestroy {
+  pokemon: Pokemon | undefined;
+  isLoading: boolean = true;
+  private routeSubscription: Subscription | undefined;
+  private pokemonDetailsSubscription: Subscription | undefined;
 
-  constructor() { }
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private pokemonService: PokemonService
+  ) { }
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.routeSubscription = this.activatedRoute.paramMap.subscribe(params => {
+      const pokemonId = params.get('id');
+      if (pokemonId) {
+        this.getPokemonDetails(pokemonId);
+      } else {
+        console.error('ID do Pokémon não encontrado na rota.');
+        this.isLoading = false;
+      }
+    });
+  }
 
+  getPokemonDetails(id: string) {
+    this.isLoading = true;
+    this.pokemonDetailsSubscription = this.pokemonService.getPokemonDetails(id).subscribe({
+      next: (data) => {
+        this.pokemon = data;
+        this.isLoading = false;
+      },
+      error: (err) => {
+        console.error('Erro ao buscar detalhes do Pokémon:', err);
+        this.isLoading = false;
+        // Opcional: exibir uma mensagem de erro para o usuário
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    // Garanta que todas as inscrições sejam canceladas para evitar vazamentos de memória
+    if (this.routeSubscription) {
+      this.routeSubscription.unsubscribe();
+    }
+    if (this.pokemonDetailsSubscription) {
+      this.pokemonDetailsSubscription.unsubscribe();
+    }
+  }
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -40,21 +40,18 @@
       </ion-col>
     </ion-row>
 
-    <!-- Spinner de carregamento -->
     <ion-row class="ion-justify-content-center" *ngIf="isLoading">
       <ion-col size="auto">
         <ion-spinner name="crescent"></ion-spinner>
       </ion-col>
     </ion-row>
 
-    <!-- Botão Exibir Mais -->
     <ion-row class="ion-justify-content-center" *ngIf="!allPokemonsLoaded && !isLoading">
       <ion-col size="auto">
         <ion-button expand="block" (click)="loadPokemons()">Exibir mais</ion-button>
       </ion-col>
     </ion-row>
 
-    <!-- Todos carregados -->
     <ion-row class="ion-justify-content-center" *ngIf="allPokemonsLoaded">
       <ion-col size="auto">
         <p>Todos os Pokémons foram carregados.</p>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+// src/app/home/home.component.ts
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
 import { MainHeaderComponent } from "../components/main-header/main-header.component";
@@ -42,14 +43,14 @@ import { Subscription } from 'rxjs'; // Import Subscription to manage subscripti
     IonProgressBar,
     HttpClientModule,
     IonSpinner
-],
+  ],
   providers: [PokemonService]
 })
-export class HomeComponent implements OnInit {
+export class HomeComponent implements OnInit, OnDestroy { // Add OnDestroy for proper cleanup
 
   pokemons: Pokemon[] = [];
   currentPage: number = 0; // Tracks the current page/offset
-  pokemonsPerPage: number = 20; // Number of Pokemons to load per request (changed from 10 to 20)
+  pokemonsPerPage: number = 20; // Number of Pokemons to load per request
   isLoading: boolean = false; // To show/hide loading spinner
   allPokemonsLoaded: boolean = false; // To disable "Load More" button when no more data
 
@@ -59,11 +60,11 @@ export class HomeComponent implements OnInit {
     private router: Router,
     private pokemonService: PokemonService
   ) {
-    addIcons({ star });
+    addIcons({ star }); // Initialize Ionicons
   }
 
   ngOnInit() {
-    this.loadPokemons(); // Load initial set of Pokemons
+    this.loadPokemons(); // Load initial set of Pokemons when component initializes
   }
 
   /**
@@ -83,17 +84,17 @@ export class HomeComponent implements OnInit {
     this.pokemonSubscription = this.pokemonService.getPokemons(this.pokemonsPerPage, offset).subscribe({
       next: (newPokemons: Pokemon[]) => {
         if (newPokemons.length > 0) {
-          this.pokemons = [...this.pokemons, ...newPokemons]; // Append new Pokemons
+          this.pokemons = [...this.pokemons, ...newPokemons]; // Append new Pokemons to the existing list
           this.currentPage++; // Increment page for the next load
-          console.log('Pokémons carregados:', this.pokemons);
+          console.log('Pokemons loaded:', this.pokemons);
         } else {
-          this.allPokemonsLoaded = true; // No more Pokemons to load
-          console.log('Todos os Pokémons foram carregados.');
+          this.allPokemonsLoaded = true; // No more Pokemons to load, mark as all loaded
+          console.log('All Pokemons have been loaded.');
         }
         this.isLoading = false; // Hide loading spinner
       },
       error: (error) => {
-        console.error('Erro ao carregar Pokémons:', error);
+        console.error('Error loading Pokemons:', error);
         this.isLoading = false; // Hide loading spinner even on error
       }
     });
@@ -104,16 +105,25 @@ export class HomeComponent implements OnInit {
    */
   ngOnDestroy() {
     if (this.pokemonSubscription) {
-      this.pokemonSubscription.unsubscribe();
+      this.pokemonSubscription.unsubscribe(); // Unsubscribe to prevent memory leaks
     }
   }
 
+  /**
+   * Handles adding a Pokemon to favorites (console log and alert for now).
+   * @param pokemon The Pokemon object to add.
+   */
   addPokemonToFavorites(pokemon: Pokemon) {
-    console.log('Adicionar aos favoritos:', pokemon.name);
-    alert(`${pokemon.name} adicionado aos favoritos!`);
+    console.log('Adding to favorites:', pokemon.name);
+    alert(`${pokemon.name} added to favorites!`); // Simple alert for user feedback
   }
 
+  /**
+   * Navigates to the Pokemon details page using its ID.
+   * @param pokemonId The ID of the Pokemon to view details for.
+   */
   viewPokemonDetails(pokemonId: number) {
-    this.router.navigate(['/tabs/details', pokemonId]);
+    console.log('Clicked Details for Pokemon ID:', pokemonId); // Debugging log
+    this.router.navigate(['/tabs/details', pokemonId]); // Navigate to the details route
   }
 }

--- a/src/app/tabs/tabs.routes.ts
+++ b/src/app/tabs/tabs.routes.ts
@@ -17,7 +17,7 @@ export const routes: Routes = [
           import('../favorites/favorites.component').then((m) => m.FavoritesComponent),
       },
       {
-        path: 'details', 
+        path: 'details/:id', // Adicionado ':id' para capturar o parâmetro do Pokémon
         loadComponent: () =>
           import('../details/main-details.component').then((m) => m.MainDetailsComponent),
       },


### PR DESCRIPTION
Feature: Adição da Tela de Detalhes do Pokémon
Este Pull Request implementa uma nova tela dedicada para exibir informações detalhadas sobre Pokémons individuais.

Principais Mudanças:

Novo MainDetailsComponent: Componente autônomo criado para exibir dados completos do Pokémon.
Integração com API: O PokemonService foi estendido para buscar detalhes específicos de Pokémons por ID na PokeAPI.
Roteamento Dinâmico: Configurado para permitir a navegação da tela inicial de Pokémons para a nova tela de detalhes, usando o ID do Pokémon como parâmetro.
Melhora na Experiência do Usuário: Agora, ao clicar em um card de Pokémon na tela inicial, o usuário pode visualizar seus atributos específicos, como nome, imagem, tipo(s), descrição, altura, peso e nível.
Esta funcionalidade aprimora significativamente a capacidade do usuário de explorar os dados dos Pokémons na aplicação.