### PR TITLE
feat: adicionando pesquisa de pokemon

### DIFF
--- a/src/app/Services/pokemon/pokemon.component.ts
+++ b/src/app/Services/pokemon/pokemon.component.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, forkJoin, of } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { map, switchMap, catchError } from 'rxjs/operators';
 import { Pokemon } from '../../Types/pokemon';
 
 @Injectable({
@@ -12,16 +12,10 @@ export class PokemonService {
 
   constructor(private http: HttpClient) {}
 
-  /**
-   * @param limit The number of Pokemons to fetch.
-   * @param offset The starting offset for the list.
-   * @returns An Observable array of Pokemon objects.
-   */
   getPokemons(limit: number = 20, offset: number = 0): Observable<Pokemon[]> {
     return this.http.get<any>(`${this.baseUrl}/pokemon?limit=${limit}&offset=${offset}`).pipe(
       map(response => response.results),
       switchMap(pokemonList => {
-        // If the list is empty, return an empty array immediately.
         if (!pokemonList || pokemonList.length === 0) {
           return of([]);
         }
@@ -31,7 +25,6 @@ export class PokemonService {
             switchMap(detail =>
               this.http.get<any>(`${this.baseUrl}/pokemon-species/${detail.id}`).pipe(
                 map(speciesData => {
-                  // Prioritize Portuguese description, fall back to English if not found
                   const flavorTextEntry =
                     speciesData.flavor_text_entries.find((entry: any) => entry.language.name === 'pt') ||
                     speciesData.flavor_text_entries.find((entry: any) => entry.language.name === 'en');
@@ -48,17 +41,11 @@ export class PokemonService {
     );
   }
 
-  /**
-   * Retrieves detailed information for a single Pokemon.
-   * @param id The ID or name of the Pokemon.
-   * @returns An Observable of a single Pokemon object.
-   */
   getPokemonDetails(id: string | number): Observable<Pokemon> {
     return this.http.get<any>(`${this.baseUrl}/pokemon/${id}`).pipe(
       switchMap((data) =>
         this.http.get<any>(`${this.baseUrl}/pokemon-species/${id}`).pipe(
           map((speciesData) => {
-            // Prioritize Portuguese description, fall back to English if not found
             const flavorTextEntry =
               speciesData.flavor_text_entries.find((entry: any) => entry.language.name === 'pt') ||
               speciesData.flavor_text_entries.find((entry: any) => entry.language.name === 'en');
@@ -70,12 +57,6 @@ export class PokemonService {
     );
   }
 
-  /**
-   * Transforms raw Pokemon API data into the custom Pokemon interface.
-   * @param data The raw Pokemon data from the API.
-   * @param description The extracted flavor text description.
-   * @returns A formatted Pokemon object.
-   */
   private transformPokemonData(data: any, description: string): Pokemon {
     const types = data.types.map((typeInfo: any) => typeInfo.type.name);
 
@@ -84,11 +65,11 @@ export class PokemonService {
       name: data.name.charAt(0).toUpperCase() + data.name.slice(1),
       type: types.map((type: string) => type.charAt(0).toUpperCase() + type.slice(1)).join('/'),
       types: types,
-      description: description.replace(/\n|\f/g, ' '), // Cleans newlines and form feeds from description
+      description: description.replace(/\n|\f/g, ' '),
       imageUrl: data.sprites.other['official-artwork'].front_default || data.sprites.front_default,
       level: Math.floor(Math.random() * 100) + 1,
-      height: data.height / 10, // Convert decimetres to meters
-      weight: data.weight / 10, // Convert hectograms to kilograms
+      height: data.height / 10,
+      weight: data.weight / 10,
     };
   }
 }

--- a/src/app/components/main-header/main-header.component.html
+++ b/src/app/components/main-header/main-header.component.html
@@ -1,34 +1,59 @@
 <ion-header [translucent]="true" class="header">
   <ion-toolbar>
     <div class="header-content">
-      <div class="icon_logo" routerLink="/tabs/tab1">
-       
-        <ion-tab-button tab="home" routerLink="/tabs/home"> <h1>POKEDEX</h1></ion-tab-button>
+      <div class="icon_logo" routerLink="/tabs/home">
+        <ion-tab-button tab="home" routerLink="/tabs/home">
+          <h1>POKEDEX</h1>
+        </ion-tab-button>
       </div>
+
       <div class="ul_header">
         <ul>
           <li>
-            
             <ion-tab-button tab="home" routerLink="/tabs/home">
               <ion-label>Home</ion-label>
             </ion-tab-button>
           </li>
-          <!-- <li>
-           
-            <ion-tab-button tab="details" routerLink="/tabs/details">
-              <ion-label>Detalhes</ion-label>
-            </ion-tab-button>
-          </li> -->
           <li>
             <ion-tab-button tab="favorites" routerLink="/tabs/favorites">
               <ion-label>Favoritos</ion-label>
             </ion-tab-button>
           </li>
-          <li>
-            <ion-searchbar placeholder="Buscar Pokémon" animated="true"></ion-searchbar>
+
+          <li class="search-container">
+            <ion-searchbar
+              placeholder="Buscar Pokémon"
+              animated="true"
+              (ionInput)="onSearchChange($event)"
+              (ionClear)="clearSearch()"
+              (ionCancel)="clearSearch()"
+            ></ion-searchbar>
           </li>
         </ul>
       </div>
     </div>
   </ion-toolbar>
 </ion-header>
+
+<div class="search-results-wrapper" *ngIf="currentSearchValue.length > 0">
+  <ion-list *ngIf="searchResults.length > 0 && !searchLoading" class="search-results-list">
+    <ion-item *ngFor="let pokemon of searchResults" routerLink="/tabs/details/{{pokemon.id}}" (click)="clearSearch()">
+      <ion-avatar slot="start">
+        <img [src]="pokemon.imageUrl" [alt]="pokemon.name" class="pokemon-search-img" />
+      </ion-avatar>
+      <ion-label>
+        <ion-text>
+          <h2>{{ pokemon.name }}</h2>
+        </ion-text>
+      </ion-label>
+    </ion-item>
+  </ion-list>
+
+  <div *ngIf="searchLoading" class="search-loading-spinner">
+    <ion-spinner name="dots"></ion-spinner>
+  </div>
+
+  <div *ngIf="!searchLoading && searchResults.length === 0" class="no-results-message">
+    <p>Nenhum Pokémon encontrado.</p>
+  </div>
+</div>

--- a/src/app/components/main-header/main-header.component.scss
+++ b/src/app/components/main-header/main-header.component.scss
@@ -1,14 +1,12 @@
-//  import color 
 @use '../../../theme/variables' as *;
-
 
 .header {
   border: 1px solid $border-header;
   box-shadow: 0 2px 4px rgba(128, 128, 128, 0.226);
   width: 90%;
   position: absolute;
-  margin-left: 5%;
-  margin-top: 1%;
+  top: 1%;
+  left: 5%;
   border-radius: 10px;
   backdrop-filter: blur(8px);
   overflow: hidden;
@@ -17,6 +15,7 @@
   justify-content: center;
   height: var(--ion-toolbar-height, 56px);
   background-color: rgba(255, 255, 255, 0.5);
+  z-index: 100;
 }
 
 ion-toolbar {
@@ -51,6 +50,14 @@ ion-toolbar {
   font-size: 1.2em;
   cursor: pointer;
   text-decoration: none;
+  ion-tab-button{
+    display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  
+    margin-top: 0;
+  }
 
   h1 {
     color: $header-gradient;
@@ -58,7 +65,8 @@ ion-toolbar {
     align-items: center;
     justify-content: center;
     font-weight: bold;
-    font-size: 1.2em;
+  
+    font-size: 22px;
     cursor: pointer;
     text-decoration: none;
     background-image: $header-gradient;
@@ -93,10 +101,9 @@ ion-toolbar {
 .ul_header ul li {
   display: flex;
   align-items: center;
- 
 }
 
-.ul_header ion-label{
+.ul_header ion-label {
   text-decoration: none;
   color: $secundery-color;
   font-weight: bold;
@@ -104,7 +111,6 @@ ion-toolbar {
   padding: 5px 10px;
   border-radius: 5px;
   transition: background-color 0.3s ease;
-  
   display: flex;
   align-items: center;
   justify-content: center;
@@ -113,7 +119,6 @@ ion-toolbar {
 
 .ul_header ion-label:hover {
   background-color: rgba(77, 77, 255, 0.1);
-  
 }
 
 .ul_header ion-searchbar {
@@ -133,17 +138,77 @@ ion-toolbar {
   padding-right: 10px !important;
 }
 
+.search-container {
+  z-index: 101;
+  min-width: 200px;
+}
+
+.search-results-wrapper {
+  position: absolute;
+  top: 70px;
+  left: auto;
+  right: 5%;
+  width: min(70%, 200px);
+  z-index: 1010;
+}
+
+.search-results-list {
+  width: 100%;
+  max-height: 200px;
+  overflow-y: auto;
+  background: var(--ion-color-light);
+  border: 1px solid var(--ion-color-medium-tint);
+  border-radius: 0 0 8px 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  padding: 0;
+  margin: 0;
+}
+
+.search-results-list ion-item {
+  --background: var(--ion-color-light);
+  --border-color: var(--ion-color-light-shade);
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.search-results-list ion-item:hover {
+  --background: var(--ion-color-light-tint);
+}
+
+.pokemon-search-img {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  margin-right: 10px;
+}
+
+.search-loading-spinner {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px;
+  background: var(--ion-color-light);
+  border: 1px solid var(--ion-color-medium-tint);
+  border-radius: 0 0 8px 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  z-index: 102;
+  color: var(--ion-color-primary);
+}
+
+.no-results-message {
+  text-align: center;
+  padding: 10px;
+  background: var(--ion-color-light);
+  border: 1px solid var(--ion-color-medium-tint);
+  border-radius: 0 0 8px 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  color: var(--ion-color-medium);
+  z-index: 1020;
+}
+
 ion-content {
   --background: #f0f2f5;
   padding-top: 80px;
   text-align: center;
   color: #333;
-}
-
-app-explore-container {
-  padding: 20px;
-  background: #fff;
-  border-radius: 10px;
-  margin: 20px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }

--- a/src/app/components/main-header/main-header.component.ts
+++ b/src/app/components/main-header/main-header.component.ts
@@ -1,27 +1,106 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { Subject, Subscription, of } from 'rxjs';
+import { debounceTime, distinctUntilChanged, switchMap, catchError, map } from 'rxjs/operators';
+
 import {
   IonHeader,
   IonToolbar,
-  IonSearchbar, IonLabel, IonTabButton } from '@ionic/angular/standalone';
+  IonSearchbar,
+  IonLabel,
+  IonTabButton,
+  IonList,
+  IonItem,
+  IonAvatar,
+  IonText,
+  IonSpinner,
+  IonContent,
+  IonTitle
+} from '@ionic/angular/standalone';
+
+import { PokemonService } from '../../Services/pokemon/pokemon.component';
+import { Pokemon } from '../../Types/pokemon';
+import { HttpClientModule } from '@angular/common/http';
 
 @Component({
   selector: 'app-main-header',
   templateUrl: './main-header.component.html',
   styleUrls: ['./main-header.component.scss'],
   standalone: true,
-  imports: [IonTabButton, IonLabel,
+  imports: [
+    CommonModule,
+    IonTabButton,
+    IonLabel,
     RouterModule,
     IonHeader,
     IonToolbar,
     IonSearchbar,
-
-  ]
+    IonList,
+    IonItem,
+    IonAvatar,
+    IonText,
+    IonSpinner,
+    HttpClientModule
+],
+  providers: [PokemonService]
 })
-export class MainHeaderComponent implements OnInit {
+export class MainHeaderComponent implements OnInit, OnDestroy {
 
-  constructor() { }
+  searchResults: Pokemon[] = [];
+  searchLoading: boolean = false;
+  public searchTerms = new Subject<string>();
+  public currentSearchValue: string = '';
 
-  ngOnInit() { }
+  private searchSubscription: Subscription | undefined;
 
+  constructor(private pokemonService: PokemonService) { }
+
+  ngOnInit() {
+    this.searchSubscription = this.searchTerms.pipe(
+      debounceTime(400),
+      distinctUntilChanged(),
+      switchMap((term: string) => {
+        this.currentSearchValue = term;
+
+        if (!term.trim()) {
+          this.searchResults = [];
+          this.searchLoading = false;
+          return of([]);
+        }
+        this.searchLoading = true;
+
+        return this.pokemonService.getPokemonDetails(term.toLowerCase()).pipe(
+          map(pokemon => {
+            this.searchLoading = false;
+            return [pokemon];
+          }),
+          catchError(error => {
+            console.error('Error in search:', error);
+            this.searchLoading = false;
+            return of([]);
+          })
+        );
+      })
+    ).subscribe(results => {
+      this.searchResults = results;
+    });
+  }
+
+  ngOnDestroy() {
+    if (this.searchSubscription) {
+      this.searchSubscription.unsubscribe();
+    }
+  }
+
+  onSearchChange(event: any) {
+    this.searchTerms.next(event.detail.value);
+  }
+
+  clearSearch() {
+    this.searchResults = [];
+    this.searchLoading = false;
+    this.searchTerms.next('');
+    this.currentSearchValue = '';
+  }
 }


### PR DESCRIPTION
Esta pull request otimiza a exibição dos resultados da busca. O campo de pesquisa (ion-searchbar) permanece no cabeçalho, mas a lista de resultados, o spinner de carregamento e a mensagem "nenhum resultado" foram movidos para um novo contêiner (.search-results-wrapper) fora do cabeçalho.

O .search-results-wrapper agora é posicionado de forma absoluta, alinhado visualmente abaixo do campo de busca. Um *ngIf foi adicionado ao wrapper para que ele só seja renderizado quando o usuário estiver digitando, garantindo que os resultados apareçam apenas quando relevantes e não sejam cortados pelo cabeçalho.